### PR TITLE
Fix missing idReadable field in YouTrack API responses

### DIFF
--- a/youtrack_mcp/api/issues.py
+++ b/youtrack_mcp/api/issues.py
@@ -58,7 +58,7 @@ class IssuesClient:
         # If the response doesn't have all needed fields, fetch more details
         if isinstance(response, dict) and response.get('$type') == 'Issue' and 'summary' not in response:
             # Get additional fields we need
-            fields = "summary,description,created,updated,project,reporter,assignee,customFields"
+            fields = "id,idReadable,summary,description,created,updated,project,reporter,assignee,customFields"
             detailed_response = self.client.get(f"issues/{issue_id}?fields={fields}")
             return Issue.model_validate(detailed_response)
         
@@ -190,7 +190,7 @@ class IssuesClient:
             List of matching issues
         """
         # Request additional fields to ensure we get summary
-        fields = "id,summary,description,created,updated,project,reporter,assignee,customFields"
+        fields = "id,idReadable,summary,description,created,updated,project,reporter,assignee,customFields"
         params = {"query": query, "$top": limit, "fields": fields}
         response = self.client.get("issues", params=params)
         

--- a/youtrack_mcp/tools/issues.py
+++ b/youtrack_mcp/tools/issues.py
@@ -36,7 +36,7 @@ class IssueTools:
         """
         try:
             # First try to get the issue data with explicit fields
-            fields = "id,summary,description,created,updated,project(id,name,shortName),reporter(id,login,name),assignee(id,login,name),customFields(id,name,value)"
+            fields = "id,idReadable,summary,description,created,updated,project(id,name,shortName),reporter(id,login,name),assignee(id,login,name),customFields(id,name,value)"
             raw_issue = self.client.get(f"issues/{issue_id}?fields={fields}")
             
             # If we got a minimal response, enhance it with default values
@@ -66,7 +66,7 @@ class IssueTools:
         """
         try:
             # Request with explicit fields to get complete data
-            fields = "id,summary,description,created,updated,project(id,name,shortName),reporter(id,login,name),assignee(id,login,name),customFields(id,name,value)"
+            fields = "id,idReadable,summary,description,created,updated,project(id,name,shortName),reporter(id,login,name),assignee(id,login,name),customFields(id,name,value)"
             params = {"query": query, "$top": limit, "fields": fields}
             raw_issues = self.client.get("issues", params=params)
             

--- a/youtrack_mcp/tools/search.py
+++ b/youtrack_mcp/tools/search.py
@@ -48,7 +48,7 @@ class SearchTools:
                 logger.info(f"Sorting by: {sort_param}")
                 
             # Request with explicit fields to get complete data
-            fields = "id,summary,description,created,updated,project(id,name,shortName),reporter(id,login,name),assignee(id,login,name),customFields(id,name,value)"
+            fields = "id,idReadable,summary,description,created,updated,project(id,name,shortName),reporter(id,login,name),assignee(id,login,name),customFields(id,name,value)"
             params = {"query": query, "$top": limit, "fields": fields}
             
             if sort_param:


### PR DESCRIPTION
## Summary

- Add `idReadable` field to YouTrack API field requests across all modules
- Ensures human-readable issue IDs (e.g., "SP-8741") are included in API responses
- Fixes issue where only internal database IDs were returned

## Changes

- Updated `youtrack_mcp/api/issues.py` to include `idReadable` in field requests
- Updated `youtrack_mcp/tools/issues.py` to include `idReadable` in field requests  
- Updated `youtrack_mcp/tools/search.py` to include `idReadable` in field requests

## Test plan

- [ ] Verify that `get_issue` returns human-readable issue IDs
- [ ] Verify that `search_issues` returns human-readable issue IDs
- [ ] Verify that `advanced_search` returns human-readable issue IDs
- [ ] Test with both cloud and self-hosted YouTrack instances

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added display of the human-readable issue ID in issue details and search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->