### PR TITLE
feat: Add get_issue_comments MCP tool

### DIFF
--- a/youtrack_mcp/api/issues.py
+++ b/youtrack_mcp/api/issues.py
@@ -205,6 +205,26 @@ class IssuesClient:
         
         return issues
     
+    def get_issue_comments(self, issue_id: str, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        """
+        Get comments for a specific issue.
+        
+        Args:
+            issue_id: The issue ID or readable ID (e.g., PROJECT-123)
+            limit: Maximum number of comments to return (optional)
+            
+        Returns:
+            List of comments for the issue
+        """
+        # Specify fields to retrieve for comments
+        fields = "id,text,author(id,login,name),created"
+        params = {"fields": fields}
+        
+        if limit is not None:
+            params["$top"] = limit
+            
+        return self.client.get(f"issues/{issue_id}/comments", params=params)
+    
     def add_comment(self, issue_id: str, text: str) -> Dict[str, Any]:
         """
         Add a comment to an issue.

--- a/youtrack_mcp/api/mcp_wrappers.py
+++ b/youtrack_mcp/api/mcp_wrappers.py
@@ -66,6 +66,33 @@ def get_issue(issue_id: str) -> Dict[str, Any]:
         logger.exception(f"Error getting issue {issue_id}")
         return {"error": str(e), "status": "error"}
 
+def get_issue_comments(issue_id: str, limit: int = 10) -> List[Dict[str, Any]]:
+    """
+    Get comments for a specific issue.
+    
+    Args:
+        issue_id: The issue ID or readable ID (e.g., PROJECT-123)
+        limit: Maximum number of comments to return (default: 10)
+        
+    Returns:
+        List of comments for the issue
+        
+    Example:
+        >>> get_issue_comments(issue_id="DEMO-123", limit=5)
+    """
+    logger.info(f"MCP wrapper: get_issue_comments({issue_id}, limit={limit})")
+    
+    # Check if API client is available
+    if issues_api is None:
+        return [{"error": "YouTrack API client failed to initialize", "status": "error"}]
+        
+    try:
+        comments = issues_api.get_issue_comments(issue_id, limit)
+        return comments if isinstance(comments, list) else []
+    except Exception as e:
+        logger.exception(f"Error getting comments for issue {issue_id}")
+        return [{"error": str(e), "status": "error"}]
+
 def add_comment(issue_id: str, text: str) -> Dict[str, Any]:
     """
     Add a comment to an issue.

--- a/youtrack_mcp/server.py
+++ b/youtrack_mcp/server.py
@@ -339,12 +339,21 @@ class YouTrackMCPServer:
                     param_names.remove('self')
                 
                 # Special handling for specific tools
-                if name in ('get_issue', 'add_comment', 'create_issue'):
+                if name in ('get_issue', 'get_issue_comments', 'add_comment', 'create_issue'):
                     # For these tools, we need to ensure the right parameter format
                     # YouTrack expects specific positional parameters
                     if name == 'get_issue' and not processed_kwargs.get('issue_id') and processed_args:
                         # If issue_id is missing but we have a positional arg, use it as issue_id
                         processed_kwargs['issue_id'] = processed_args[0]
+                        processed_args = []
+                    
+                    elif name == 'get_issue_comments':
+                        # For get_issue_comments, we need issue_id and optional limit
+                        if len(processed_args) >= 1 and not processed_kwargs.get('issue_id'):
+                            processed_kwargs['issue_id'] = processed_args[0]
+                            processed_args = processed_args[1:]
+                        if len(processed_args) >= 1 and not processed_kwargs.get('limit'):
+                            processed_kwargs['limit'] = processed_args[0]
                         processed_args = []
                     
                     elif name == 'add_comment':
@@ -789,7 +798,7 @@ class YouTrackMCPServer:
             # Determine if this tool should use streaming
             # For now, assume all tools except Issue tools can stream
             should_stream = not name.startswith("issues_") and not name in [
-                "get_issue", "get_issue_raw", "search_issues", "create_issue", "add_comment"
+                "get_issue", "get_issue_raw", "get_issue_comments", "search_issues", "create_issue", "add_comment"
             ]
             
             # Update counts

--- a/youtrack_mcp/tools/issues.py
+++ b/youtrack_mcp/tools/issues.py
@@ -176,6 +176,27 @@ class IssueTools:
             return json.dumps({"error": str(e), "status": "error"})
     
     @sync_wrapper        
+    def get_issue_comments(self, issue_id: str, limit: int = 10) -> str:
+        """
+        Get comments for a specific issue.
+        
+        FORMAT: get_issue_comments(issue_id="DEMO-123", limit=10)
+        
+        Args:
+            issue_id: The issue ID or readable ID (e.g., PROJECT-123)
+            limit: Maximum number of comments to return (optional, default: 10)
+            
+        Returns:
+            JSON string with issue comments
+        """
+        try:
+            comments = self.issues_api.get_issue_comments(issue_id, limit)
+            return json.dumps(comments, indent=2)
+        except Exception as e:
+            logger.exception(f"Error getting comments for issue {issue_id}")
+            return json.dumps({"error": str(e)})
+    
+    @sync_wrapper        
     def add_comment(self, issue_id: str, text: str) -> str:
         """
         Add a comment to an issue.
@@ -227,6 +248,13 @@ class IssueTools:
                     "project": "The project ID or short name (e.g., 'DEMO' or '0-0')",
                     "summary": "The issue title/summary",
                     "description": "Detailed description of the issue (optional)"
+                }
+            },
+            "get_issue_comments": {
+                "description": "Get comments for a specific issue in YouTrack. Returns comment details including author and creation time.",
+                "parameter_descriptions": {
+                    "issue_id": "The issue ID or readable ID (e.g., PROJECT-123)",
+                    "limit": "Maximum number of comments to return (optional, default: 10)"
                 }
             },
             "add_comment": {

--- a/youtrack_mcp/tools/loader.py
+++ b/youtrack_mcp/tools/loader.py
@@ -39,7 +39,7 @@ def load_all_tools() -> Dict[str, Callable]:
     Available tools:
     - get_projects, get_project, get_project_by_name, get_project_issues, get_custom_fields, 
       create_project, update_project (from ProjectTools)
-    - get_issue, get_issue_raw, search_issues, create_issue, add_comment (from IssueTools)
+    - get_issue, get_issue_raw, get_issue_comments, search_issues, create_issue, add_comment (from IssueTools)
     - get_user, get_user_by_login, get_user_groups, search_users, get_current_user (from UserTools)
     - advanced_search, filter_issues, search_with_custom_fields (from SearchTools)
     


### PR DESCRIPTION
- Add get_issue_comments method to IssuesClient API layer
- Implement get_issue_comments tool in IssueTools class with sync wrapper
- Add MCP wrapper function for get_issue_comments in mcp_wrappers.py
- Update server.py to handle get_issue_comments parameter extraction
- Add get_issue_comments to tool registration and documentation
- Support for retrieving issue comments with fields: id, text, author, created
- Optional limit parameter to control number of comments returned
- Follows existing patterns for issue-related tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve comments for a specific issue, with an optional limit on the number of comments returned.

* **Documentation**
  * Updated documentation to include the new tool for fetching issue comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->