### PR TITLE
Add idReadable field to issue queries

### DIFF
--- a/youtrack_mcp/tools/issues.py
+++ b/youtrack_mcp/tools/issues.py
@@ -36,7 +36,7 @@ class IssueTools:
         """
         try:
             # First try to get the issue data with explicit fields
-            fields = "id,summary,description,created,updated,project(id,name,shortName),reporter(id,login,name),assignee(id,login,name),customFields(id,name,value)"
+            fields = "id,idReadable,summary,description,created,updated,project(id,name,shortName),reporter(id,login,name),assignee(id,login,name),customFields(id,name,value)"
             raw_issue = self.client.get(f"issues/{issue_id}?fields={fields}")
             
             # If we got a minimal response, enhance it with default values
@@ -66,7 +66,7 @@ class IssueTools:
         """
         try:
             # Request with explicit fields to get complete data
-            fields = "id,summary,description,created,updated,project(id,name,shortName),reporter(id,login,name),assignee(id,login,name),customFields(id,name,value)"
+            fields = "id,idReadable,summary,description,created,updated,project(id,name,shortName),reporter(id,login,name),assignee(id,login,name),customFields(id,name,value)"
             params = {"query": query, "$top": limit, "fields": fields}
             raw_issues = self.client.get("issues", params=params)
             
@@ -258,7 +258,8 @@ class IssueTools:
             Raw JSON string with the issue data
         """
         try:
-            raw_issue = self.client.get(f"issues/{issue_id}")
+            fields = "id,idReadable,summary,description,created,updated,project(id,name,shortName),reporter(id,login,name),assignee(id,login,name),customFields(id,name,value)"
+            raw_issue = self.client.get(f"issues/{issue_id}?fields={fields}")
             return json.dumps(raw_issue, indent=2)
         except Exception as e:
             logger.exception(f"Error getting raw issue {issue_id}")

--- a/youtrack_mcp/tools/search.py
+++ b/youtrack_mcp/tools/search.py
@@ -48,7 +48,7 @@ class SearchTools:
                 logger.info(f"Sorting by: {sort_param}")
                 
             # Request with explicit fields to get complete data
-            fields = "id,summary,description,created,updated,project(id,name,shortName),reporter(id,login,name),assignee(id,login,name),customFields(id,name,value)"
+            fields = "id,idReadable,summary,description,created,updated,project(id,name,shortName),reporter(id,login,name),assignee(id,login,name),customFields(id,name,value)"
             params = {"query": query, "$top": limit, "fields": fields}
             
             if sort_param:


### PR DESCRIPTION
## Summary
- Added `idReadable` field to all issue-related API queries
- Provides human-readable issue identifiers (e.g., "PROJ-123") alongside numeric IDs
- Improves issue identification and debugging capabilities

## Changes
- Modified `get_issue()` to include `idReadable` in field list
- Modified `search_issues()` to include `idReadable` in field list  
- Modified `get_issue_raw()` to include `idReadable` in field list
- Modified `advanced_search()` to include `idReadable` in field list

## Test plan
- [x] Verified field is properly included in API requests
- [x] Confirmed existing functionality remains unchanged
- [x] Tested with YouTrack API to ensure `idReadable` is returned

This is a backward-compatible enhancement that adds useful issue identification information without breaking existing functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display of the human-readable issue identifier in issue details and search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->