### PR TITLE
Add support for version/sprint custom fields in YouTrack issues

### DIFF
--- a/tests/unit/tools/issues/test_utilities.py
+++ b/tests/unit/tools/issues/test_utilities.py
@@ -68,7 +68,7 @@ class TestUtilities:
         diagnostics = ["diagnose_workflow_restrictions", "get_help"]
         custom_fields = ["update_custom_fields", "batch_update_custom_fields", "get_custom_fields", "validate_custom_field", "get_available_custom_field_values"]
         linking = ["link_issues", "get_issue_links", "get_available_link_types", "add_dependency", "remove_dependency", "add_relates_link", "add_duplicate_link"]
-        attachments = ["get_issue_raw", "get_attachment_content"]
+        attachments = ["get_issue_raw", "get_attachment_content", "delete_attachment"]
 
         all_expected = basic_ops + dedicated_updates + diagnostics + custom_fields + linking + attachments
 

--- a/youtrack_mcp/api/issues.py
+++ b/youtrack_mcp/api/issues.py
@@ -566,7 +566,11 @@ class IssuesClient:
                 use_simple_approach = False
             
             update_data = {"customFields": []}
-            
+            _VERSION_FIELD_NAMES = frozenset([
+                'sprints', 'sprint', 'fix versions', 'fix version',
+                'affected versions', 'affected version', 'milestone', 'release'
+            ])
+
             for field_name, raw_field_value in custom_fields.items():
                 # Normalize complex object formats to simple strings first
                 field_value = self._normalize_field_value(raw_field_value)
@@ -604,11 +608,14 @@ class IssuesClient:
                         field_data = self._create_user_field_object(field_name, field_value)
                     elif field_name.lower() in ['spent time']:
                         field_data = self._create_period_field_object(field_name, field_value)
+                    elif field_name.lower() in _VERSION_FIELD_NAMES:
+                        # Known multi-version field names — detected by name, no extra API call
+                        field_data = self._create_version_field_object(project_id, field_name, raw_field_value, multi=True)
                     else:
-                        # Query the schema to detect version/sprint fields
+                        # Query the schema to detect other version-type fields
                         value_type = self._get_field_value_type(project_id, field_name)
                         if value_type == "version":
-                            field_data = self._create_version_field_object(project_id, field_name, field_value)
+                            field_data = self._create_version_field_object(project_id, field_name, raw_field_value, multi=True)
                         else:
                             # Default to enum for unknown fields
                             field_data = self._create_enum_field_object(project_id, field_name, field_value)
@@ -1747,7 +1754,11 @@ class IssuesClient:
                 use_simple_approach = False
             
             update_data = {"customFields": []}
-            
+            _VERSION_FIELD_NAMES = frozenset([
+                'sprints', 'sprint', 'fix versions', 'fix version',
+                'affected versions', 'affected version', 'milestone', 'release'
+            ])
+
             for field_name, raw_field_value in custom_fields.items():
                 # Normalize complex object formats to simple strings first
                 field_value = self._normalize_field_value(raw_field_value)
@@ -1785,11 +1796,14 @@ class IssuesClient:
                         field_data = self._create_user_field_object(field_name, field_value)
                     elif field_name.lower() in ['spent time']:
                         field_data = self._create_period_field_object(field_name, field_value)
+                    elif field_name.lower() in _VERSION_FIELD_NAMES:
+                        # Known multi-version field names — detected by name, no extra API call
+                        field_data = self._create_version_field_object(project_id, field_name, raw_field_value, multi=True)
                     else:
-                        # Query the schema to detect version/sprint fields
+                        # Query the schema to detect other version-type fields
                         value_type = self._get_field_value_type(project_id, field_name)
                         if value_type == "version":
-                            field_data = self._create_version_field_object(project_id, field_name, field_value)
+                            field_data = self._create_version_field_object(project_id, field_name, raw_field_value, multi=True)
                         else:
                             # Default to enum for unknown fields
                             field_data = self._create_enum_field_object(project_id, field_name, field_value)
@@ -1903,6 +1917,10 @@ class IssuesClient:
 
     def _create_enhanced_field_object(self, project_id: str, field_name: str, field_value: Any) -> Dict[str, Any]:
         """Create enhanced field object with proper YouTrack objects and actual IDs."""
+        _version_field_names = frozenset([
+            'sprints', 'sprint', 'fix versions', 'fix version',
+            'affected versions', 'affected version', 'milestone', 'release'
+        ])
         try:
             field_name_lower = field_name.lower()
 
@@ -1914,11 +1932,13 @@ class IssuesClient:
                 return self._create_enum_field_object(project_id, field_name, field_value)
             elif field_name_lower in ['assignee', 'reporter']:
                 return self._create_user_field_object(field_name, field_value)
+            elif field_name_lower in _version_field_names:
+                return self._create_version_field_object(project_id, field_name, field_value, multi=True)
             else:
                 # Query the schema to determine the actual field type
                 value_type = self._get_field_value_type(project_id, field_name)
                 if value_type == "version":
-                    return self._create_version_field_object(project_id, field_name, field_value)
+                    return self._create_version_field_object(project_id, field_name, field_value, multi=True)
                 else:
                     # Default to enum for unknown fields
                     return self._create_enum_field_object(project_id, field_name, field_value)
@@ -2145,8 +2165,16 @@ class IssuesClient:
             logger.warning(f"Error getting field value type for '{field_name}': {e}")
             return ""
 
-    def _create_version_field_object(self, project_id: str, field_name: str, field_value: Any) -> Dict[str, Any]:
-        """Create proper VersionBundleElement object for version/sprint multi-value fields."""
+    def _create_version_field_object(self, project_id: str, field_name: str, field_value: Any, multi: bool = True) -> Dict[str, Any]:
+        """Create proper VersionBundleElement object for version/sprint fields.
+
+        Args:
+            project_id: Project identifier for allowed-value lookup
+            field_name: Custom field name
+            field_value: String or list of version names
+            multi: True for MultiVersionIssueCustomField (array value),
+                   False for SingleVersionIssueCustomField (single object value)
+        """
         try:
             # Accept either a string (single value) or list of values
             if isinstance(field_value, list):
@@ -2162,31 +2190,48 @@ class IssuesClient:
             value_elements = []
             for name in value_names:
                 version_id = None
+                matched_name = name
                 for v in allowed_values:
                     if v.get('name', '').lower() == name.lower():
                         version_id = v.get('id')
+                        matched_name = v.get('name', name)  # Use API name for exact case
                         break
-                element = {"$type": "VersionBundleElement", "name": name}
+                element = {"$type": "VersionBundleElement", "name": matched_name}
                 if version_id:
                     element["id"] = version_id
                 value_elements.append(element)
 
-            return {
-                "$type": "MultiVersionIssueCustomField",
-                "name": field_name,
-                "value": value_elements
-            }
+            if multi:
+                return {
+                    "$type": "MultiVersionIssueCustomField",
+                    "name": field_name,
+                    "value": value_elements
+                }
+            else:
+                single_value = value_elements[0] if value_elements else {"$type": "VersionBundleElement", "name": str(field_value)}
+                return {
+                    "$type": "SingleVersionIssueCustomField",
+                    "name": field_name,
+                    "value": single_value
+                }
         except Exception as e:
             logger.warning(f"Error creating version field object for '{field_name}': {e}, using minimal format")
-            if isinstance(field_value, list):
-                value_elements = [{"$type": "VersionBundleElement", "name": self._normalize_field_value(v)} for v in field_value]
+            if multi:
+                if isinstance(field_value, list):
+                    value_elements = [{"$type": "VersionBundleElement", "name": self._normalize_field_value(v)} for v in field_value]
+                else:
+                    value_elements = [{"$type": "VersionBundleElement", "name": self._normalize_field_value(field_value)}]
+                return {
+                    "$type": "MultiVersionIssueCustomField",
+                    "name": field_name,
+                    "value": value_elements
+                }
             else:
-                value_elements = [{"$type": "VersionBundleElement", "name": self._normalize_field_value(field_value)}]
-            return {
-                "$type": "MultiVersionIssueCustomField",
-                "name": field_name,
-                "value": value_elements
-            }
+                return {
+                    "$type": "SingleVersionIssueCustomField",
+                    "name": field_name,
+                    "value": {"$type": "VersionBundleElement", "name": self._normalize_field_value(field_value)}
+                }
 
     def get_issue_custom_fields(self, issue_id: str) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for handling version and sprint custom fields in YouTrack issue operations. Previously, unknown custom field types defaulted to enum fields, which caused failures when updating version/sprint fields. The changes introduce proper detection and handling of version-type fields throughout the codebase.

## Key Changes

- **Version field detection**: Added `_get_field_value_type()` method to query the project schema and detect version/sprint fields by their valueType
- **Version field creation**: Implemented `_create_version_field_object()` to properly construct `MultiVersionIssueCustomField` objects with `VersionBundleElement` values
- **Enhanced field type mapping**: Updated `_get_issue_custom_field_type()` to recognize version fields and return the correct `MultiVersionIssueCustomField` type
- **Field value formatting**: Added version field handling in `_format_field_value()` to properly format version values as arrays of `VersionBundleElement` objects
- **Simple field object support**: Extended `_create_simple_field_object()` to recognize common version/sprint field names (fix versions, affected versions, sprints, milestone, release) and handle them as multi-value version fields
- **Schema-aware field updates**: Modified `_update_other_custom_fields()` and `_create_enhanced_field_object()` to query the schema before defaulting to enum fields, enabling proper handling of version fields
- **Create issue enhancement**: Added optional `custom_fields` parameter to `create_issue()` tool to allow setting custom fields (including version fields) at issue creation time
- **Code cleanup**: Fixed trailing whitespace inconsistencies throughout the file

## Implementation Details

- Version fields are detected by checking if the field's valueType is "version" in the project schema
- Version field values are wrapped in `VersionBundleElement` objects with proper `$type` designation
- The implementation supports both single values and lists of values for version fields
- Version IDs are looked up from allowed values when available to provide complete field objects
- Graceful fallback to minimal format if version ID lookup fails
- The `create_issue()` tool now applies custom fields after issue creation, enabling version field assignment during issue creation workflow

https://claude.ai/code/session_011W1EWPMJ87kW6VL3ckYN28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YouTrack version field handling with enhanced error recovery; operations now gracefully degrade to simplified formats when detailed field metadata is unavailable, making workflows more resilient to API variations.

* **Tests**
  * Extended test coverage for attachment-related functionality to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->